### PR TITLE
Add web3-discover to Other Interesting Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,4 @@ Please share it among your friend, collegues, students & communities.
 | 1 | [Web3.Storage](https://web3.storage/) | decentralized storaging of Data via our API or our web UI for free. IPFS and Filecoin storage providers |
 | 2 | [Web3 Funding Database](https://docs.google.com/spreadsheets/d/1Qd42u8WWnu5yYOAE5u-qLjjbLTlqGKzfFmOywHBBLFQ/edit#gid=246452209) | Database of all Web3 companies funding by Milkroad |
 | 3 | [Continuum](https://www.continuum.xyz/) | THE LEARNING PLATFORM FOR CREATIVES, earn crypto rewards for learning |
+| 4 | [web3-discover](https://web3-discover.vercel.app/) | The airdrop hunter's honest map — hand-vetted, scam-filtered directory of currently-active web3 airdrops with effort, cost floor, deadline, and risk flag on every entry. No paid placements pretending to be listings. |


### PR DESCRIPTION
Adding [web3-discover](https://web3-discover.vercel.app/) to the **Other Interesting Projects** section.

It's a hand-vetted, scam-filtered directory of currently-active web3 airdrops — every entry has the action, effort, cost floor, deadline, and a risk flag (verified / unverified). Suspected scams are excluded outright rather than silently hidden.

- 22 active multi-chain entries at launch (Solana, Ethereum L1/L2, Hyperliquid, etc.)
- No paid placements pretending to be listings — explicit affiliate disclosure
- No wallet-connect, no custodial "claim" pages
- RSS feed at `/rss.xml` for hunters who don't want to visit every day

Happy to adjust positioning / wording if you'd prefer a different section.